### PR TITLE
feat(otel): add function to extract ctx from nats

### DIFF
--- a/pkg/telemetry/header.go
+++ b/pkg/telemetry/header.go
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package telemetry
+
+import (
+	"context"
+
+	"github.com/nats-io/nats.go/micro"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+// GetCtxFromReq extracts distributed tracing context from a NATS micro service request.
+// It uses OpenTelemetry's text map propagator to extract trace context from the request
+// headers and returns a new context containing the propagated trace information.
+// If no trace context is found in the headers, it returns a context derived from
+// context.Background().
+func GetCtxFromReq(req micro.Request) context.Context {
+	return otel.GetTextMapPropagator().Extract(context.Background(), propagation.HeaderCarrier(req.Headers()))
+}


### PR DESCRIPTION
This adds a simple convenience function to extract a context from a NATS request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a helper to extract OpenTelemetry trace context from incoming NATS microservice requests for improved distributed tracing.
  * Ensures seamless interoperability with configured OpenTelemetry propagators.
  * Gracefully falls back to a baseline context when requests lack trace headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->