### PR TITLE
feat(state): add state package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/nats-io/nats-server/v2 v2.11.8
 	github.com/nats-io/nats.go v1.45.0
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25
+	github.com/qmuntal/stateless v1.7.2
 	github.com/quic-go/quic-go v0.54.0
 	github.com/rs/cors v1.11.1
 	github.com/rs/zerolog v1.34.0
@@ -27,6 +28,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/log v0.14.0
+	go.opentelemetry.io/otel/trace v1.38.0
 	golang.org/x/crypto v0.41.0
 	golang.org/x/sys v0.35.0
 	google.golang.org/genproto v0.0.0-20250826171959-ef028d996bc1
@@ -59,7 +61,6 @@ require (
 	github.com/stoewer/go-strcase v1.3.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
-	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.uber.org/mock v0.5.0 // indirect
 	golang.org/x/exp v0.0.0-20250718183923-645b1fa84792 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20220613132600-b0d781184e0d // indirect

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/procfs v0.0.0-20180725123919-05ee40e3a273/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/qmuntal/stateless v1.7.2 h1:FqCErOP+Hf+/FByJt/S4UOLHFJeTf8CbMrEE0AkYT8k=
+github.com/qmuntal/stateless v1.7.2/go.mod h1:n1HjRBM/cq4uCr3rfUjaMkgeGcd+ykAZwkjLje6jGBM=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
 github.com/quic-go/qpack v0.5.1/go.mod h1:+PC4XFrEskIVkcLzpEkbLqq1uCoxPhQuvK5rH1ZgaEg=
 github.com/quic-go/quic-go v0.54.0 h1:6s1YB9QotYI6Ospeiguknbp2Znb/jZYjZLRXn9kMQBg=

--- a/pkg/state/config.go
+++ b/pkg/state/config.go
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package state
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Config holds the configuration for a state machine.
+type Config struct {
+	// Name is the unique identifier for the state machine
+	Name string
+	// Description provides human-readable information about the state machine
+	Description string
+	// InitialState is the starting state of the machine
+	InitialState string
+	// States defines all possible states
+	States []StateDefinition
+	// Transitions defines all allowed state transitions
+	Transitions []TransitionDefinition
+	// PersistState enables state persistence
+	PersistState bool
+	// StateTimeout is the maximum time a state transition can take
+	StateTimeout time.Duration
+	// EnableMetrics enables state transition metrics collection
+	EnableMetrics bool
+	// EnableTracing enables distributed tracing for state transitions
+	EnableTracing bool
+}
+
+// StateDefinition defines a single state in the state machine.
+type StateDefinition struct { //nolint:revive // keeping struct name for clarity considering we have TransitionDefinition as well
+	// Name is the unique identifier for the state
+	Name string
+	// Description provides human-readable information about the state
+	Description string
+	// OnEntry is called when entering this state
+	OnEntry StateAction
+	// OnExit is called when leaving this state
+	OnExit StateAction
+}
+
+// TransitionDefinition defines a valid state transition.
+type TransitionDefinition struct {
+	// From is the source state
+	From string
+	// To is the destination state
+	To string
+	// Trigger is the event that causes the transition
+	Trigger string
+	// Guard is an optional condition that must be true for the transition
+	Guard TransitionGuard
+	// Action is executed during the transition
+	Action TransitionAction
+}
+
+// StateAction is a function executed when entering or exiting a state.
+type StateAction func(ctx context.Context) error //nolint:revive // keeping signature for clarity considering we have TransitionAction as well
+
+// TransitionAction is a function executed during a state transition.
+type TransitionAction func(ctx context.Context, from, to string) error
+
+// TransitionGuard is a function that determines if a transition is allowed.
+type TransitionGuard func(ctx context.Context) bool
+
+// Option represents a configuration option for the state machine.
+type Option interface {
+	apply(*Config)
+}
+
+type nameOption struct {
+	name string
+}
+
+func (o *nameOption) apply(c *Config) {
+	c.Name = o.name
+}
+
+// WithName sets the name of the state machine.
+func WithName(name string) Option {
+	return &nameOption{name: name}
+}
+
+type descriptionOption struct {
+	description string
+}
+
+func (o *descriptionOption) apply(c *Config) {
+	c.Description = o.description
+}
+
+// WithDescription sets the description of the state machine.
+func WithDescription(description string) Option {
+	return &descriptionOption{description: description}
+}
+
+type initialStateOption struct {
+	state string
+}
+
+func (o *initialStateOption) apply(c *Config) {
+	c.InitialState = o.state
+}
+
+// WithInitialState sets the initial state of the state machine.
+func WithInitialState(state string) Option {
+	return &initialStateOption{state: state}
+}
+
+type statesOption struct {
+	states []StateDefinition
+}
+
+func (o *statesOption) apply(c *Config) {
+	c.States = append([]StateDefinition(nil), o.states...)
+}
+
+// WithStates sets the available states for the state machine.
+func WithStates(states ...StateDefinition) Option {
+	return &statesOption{states: states}
+}
+
+type transitionsOption struct {
+	transitions []TransitionDefinition
+}
+
+func (o *transitionsOption) apply(c *Config) {
+	c.Transitions = append([]TransitionDefinition(nil), o.transitions...)
+}
+
+// WithTransitions sets the allowed transitions for the state machine.
+func WithTransitions(transitions ...TransitionDefinition) Option {
+	return &transitionsOption{transitions: transitions}
+}
+
+type persistStateOption struct {
+	persist bool
+}
+
+func (o *persistStateOption) apply(c *Config) {
+	c.PersistState = o.persist
+}
+
+// WithPersistState enables or disables state persistence.
+func WithPersistState(persist bool) Option {
+	return &persistStateOption{persist: persist}
+}
+
+type stateTimeoutOption struct {
+	timeout time.Duration
+}
+
+func (o *stateTimeoutOption) apply(c *Config) {
+	c.StateTimeout = o.timeout
+}
+
+// WithStateTimeout sets the maximum duration for state transitions.
+func WithStateTimeout(timeout time.Duration) Option {
+	return &stateTimeoutOption{timeout: timeout}
+}
+
+type enableMetricsOption struct {
+	enable bool
+}
+
+func (o *enableMetricsOption) apply(c *Config) {
+	c.EnableMetrics = o.enable
+}
+
+// WithMetrics enables or disables metrics collection.
+func WithMetrics(enable bool) Option {
+	return &enableMetricsOption{enable: enable}
+}
+
+type enableTracingOption struct {
+	enable bool
+}
+
+func (o *enableTracingOption) apply(c *Config) {
+	c.EnableTracing = o.enable
+}
+
+// WithTracing enables or disables distributed tracing.
+func WithTracing(enable bool) Option {
+	return &enableTracingOption{enable: enable}
+}
+
+// NewConfig creates a new state machine configuration with the provided options.
+func NewConfig(opts ...Option) *Config {
+	cfg := &Config{
+		Name:          "",
+		Description:   "",
+		InitialState:  "unspecified",
+		States:        []StateDefinition{},
+		Transitions:   []TransitionDefinition{},
+		PersistState:  false,
+		StateTimeout:  30 * time.Second,
+		EnableMetrics: true,
+		EnableTracing: true,
+	}
+
+	for _, opt := range opts {
+		opt.apply(cfg)
+	}
+
+	return cfg
+}
+
+// Validate checks if the configuration is valid.
+func (c *Config) Validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("%w: name cannot be empty", ErrInvalidConfig)
+	}
+
+	if c.InitialState == "" {
+		return fmt.Errorf("%w: initial state cannot be empty", ErrInvalidConfig)
+	}
+
+	if len(c.States) == 0 {
+		return fmt.Errorf("%w: at least one state must be defined", ErrInvalidConfig)
+	}
+
+	// Check if initial state exists in states list
+	initialStateFound := false
+	stateNames := make(map[string]bool)
+	for _, state := range c.States {
+		if state.Name == "" {
+			return fmt.Errorf("%w: state name cannot be empty", ErrInvalidConfig)
+		}
+		if stateNames[state.Name] {
+			return fmt.Errorf("%w: duplicate state name: %s", ErrInvalidConfig, state.Name)
+		}
+		stateNames[state.Name] = true
+		if state.Name == c.InitialState {
+			initialStateFound = true
+		}
+	}
+
+	if !initialStateFound {
+		return fmt.Errorf("%w: initial state %s not found in states list", ErrInvalidConfig, c.InitialState)
+	}
+
+	// Validate transitions
+	for _, transition := range c.Transitions {
+		if transition.From == "" || transition.To == "" {
+			return fmt.Errorf("%w: transition from and to states cannot be empty", ErrInvalidConfig)
+		}
+		if transition.Trigger == "" {
+			return fmt.Errorf("%w: transition trigger cannot be empty", ErrInvalidConfig)
+		}
+		if !stateNames[transition.From] {
+			return fmt.Errorf("%w: transition from state %s not found", ErrInvalidConfig, transition.From)
+		}
+		if !stateNames[transition.To] {
+			return fmt.Errorf("%w: transition to state %s not found", ErrInvalidConfig, transition.To)
+		}
+	}
+
+	if c.StateTimeout <= 0 {
+		return fmt.Errorf("%w: state timeout must be positive", ErrInvalidConfig)
+	}
+
+	return nil
+}

--- a/pkg/state/doc.go
+++ b/pkg/state/doc.go
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+// Package state provides a comprehensive state machine implementation for BMC (Baseboard Management Controller)
+// systems and other applications requiring robust state management with persistence, observability, and
+// concurrent access support.
+//
+// # Overview
+//
+// This package implements finite state machines (FSMs) with the following key features:
+//   - Thread-safe operations with read-write mutexes
+//   - State persistence with configurable callbacks
+//   - Distributed tracing and metrics collection
+//   - Configurable timeouts for state transitions
+//   - Guard conditions and transition actions
+//   - State entry/exit actions
+//   - Broadcast notifications for state changes
+//   - DOT graph generation for visualization
+//   - Multi-state machine management
+//
+// # Core Concepts
+//
+// State Machine: A computational model consisting of a finite number of states, transitions between
+// those states, and actions. At any given time, the machine is in exactly one state.
+//
+// State: A distinct condition or situation in which the state machine can exist. Each state can have
+// optional entry and exit actions that are executed when entering or leaving the state.
+//
+// Transition: A change from one state to another, triggered by an event (trigger). Transitions can
+// have guard conditions that must be satisfied and actions that are executed during the transition.
+//
+// Trigger: An event or signal that can cause a state transition. Triggers are only valid for specific
+// states and their associated transitions.
+//
+// Guard: A boolean condition that must be true for a transition to occur. Guards provide additional
+// control over when transitions are allowed.
+//
+// Action: Code that is executed either when entering/exiting a state or during a transition.
+//
+// # Basic Usage
+//
+// Creating a simple state machine:
+//
+//	config := NewConfig(
+//		WithName("power-management"),
+//		WithDescription("BMC power state management"),
+//		WithInitialState("off"),
+//		WithStates(
+//			StateDefinition{
+//				Name: "off",
+//				Description: "System is powered off",
+//				OnEntry: func(ctx context.Context) error {
+//					// Perform power-off actions
+//					return nil
+//				},
+//			},
+//			StateDefinition{
+//				Name: "on",
+//				Description: "System is powered on",
+//				OnEntry: func(ctx context.Context) error {
+//					// Perform power-on actions
+//					return nil
+//				},
+//			},
+//		),
+//		WithTransitions(
+//			TransitionDefinition{
+//				From: "off",
+//				To: "on",
+//				Trigger: "power_on",
+//				Action: func(ctx context.Context, from, to string) error {
+//					// Execute power-on sequence
+//					return nil
+//				},
+//			},
+//			TransitionDefinition{
+//				From: "on",
+//				To: "off",
+//				Trigger: "power_off",
+//				Guard: func(ctx context.Context) bool {
+//					// Check if safe to power off
+//					return true
+//				},
+//			},
+//		),
+//		WithPersistState(true),
+//	)
+//
+//	sm, err := New(config)
+//	if err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	// Set persistence callback before starting
+//	sm.SetPersistenceCallback(func(machineName, state string) error {
+//		// Save state to database, file, etc.
+//		return saveStateToStorage(machineName, state)
+//	})
+//
+//	// Start the state machine
+//	ctx := context.Background()
+//	if err := sm.Start(ctx); err != nil {
+//		log.Fatal(err)
+//	}
+//
+//	// Trigger a state transition
+//	if err := sm.Fire(ctx, "power_on", nil); err != nil {
+//		log.Printf("Transition failed: %v", err)
+//	}
+//
+// # State Persistence
+//
+// The package supports state persistence through configurable callbacks. When enabled,
+// the current state is persisted whenever it changes:
+//
+//	sm.SetPersistenceCallback(func(machineName, state string) error {
+//		// Save state to database, file, etc.
+//		return saveStateToStorage(machineName, state)
+//	})
+//
+// Note: Persistence callbacks must be set before starting the state machine.
+//
+// # State Change Notifications
+//
+// Applications can receive notifications when state changes occur:
+//
+//	sm.SetBroadcastCallback(func(machineName, previousState, currentState, trigger string) error {
+//		// Notify other components, send events, etc.
+//		return notifyStateChange(machineName, previousState, currentState, trigger)
+//	})
+//
+// Note: Broadcast callbacks must be set before starting the state machine.
+//
+// # Multi-State Machine Management
+//
+// The Manager type allows managing multiple state machines:
+//
+//	manager := NewManager()
+//	manager.AddStateMachine(powerSM)
+//	manager.AddStateMachine(thermalSM)
+//	manager.AddStateMachine(networkSM)
+//
+//	// Get a specific state machine
+//	sm, err := manager.GetStateMachine("power-management")
+//	if err != nil {
+//		log.Printf("State machine not found: %v", err)
+//	}
+//
+// # Observability
+//
+// The package provides built-in support for observability:
+//
+// Tracing: Distributed tracing support using OpenTelemetry provides visibility into
+// state transition flows across service boundaries. Enable with WithTracing(true).
+//
+// Metrics: Metrics collection can be enabled with WithMetrics(true) in the configuration.
+//
+// Logging: Comprehensive error reporting with structured error types for different
+// failure scenarios.
+//
+// # Thread Safety
+//
+// All state machine operations are thread-safe. Multiple goroutines can safely:
+//   - Query the current state
+//   - Check if triggers can be fired
+//   - Trigger state transitions
+//   - Access state machine metadata
+//
+// The implementation uses read-write mutexes to allow concurrent reads while ensuring
+// exclusive access for state modifications.
+//
+// # Error Handling
+//
+// The package defines specific error types for different failure scenarios:
+//   - Configuration errors (ErrInvalidConfig)
+//   - State/transition errors (ErrInvalidState, ErrInvalidTransition, ErrInvalidTrigger)
+//   - Timeout errors (ErrTransitionTimeout)
+//   - Guard/action failures (ErrTransitionGuardFailed, ErrStateActionFailed, ErrTransitionActionFailed)
+//   - Concurrency errors (ErrConcurrentModification)
+//   - Persistence errors (ErrPersistenceFailed)
+//   - Lifecycle errors (ErrStateMachineNotStarted, ErrStateMachineAlreadyStarted, ErrStateMachineStopped)
+//
+// # BMC Integration
+//
+// This package is specifically designed for BMC systems where reliable state management
+// is critical for:
+//   - Power management (on/off/reset states)
+//   - Thermal management (normal/warning/critical states)
+//   - Boot sequence management (POST/boot/ready states)
+//   - Network interface management (up/down/configuring states)
+//   - Sensor monitoring (active/inactive/fault states)
+//   - Firmware update processes (idle/downloading/updating/verifying states)
+//
+// The persistence and observability features ensure that state information survives
+// BMC reboots and provides visibility into system behavior for debugging and monitoring.
+package state

--- a/pkg/state/errors.go
+++ b/pkg/state/errors.go
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package state
+
+import "errors"
+
+var (
+	// ErrInvalidConfig indicates that the state machine configuration is invalid.
+	ErrInvalidConfig = errors.New("invalid state machine configuration")
+	// ErrStateMachineNotFound indicates that the requested state machine does not exist.
+	ErrStateMachineNotFound = errors.New("state machine not found")
+	// ErrStateMachineExists indicates that a state machine with the same name already exists.
+	ErrStateMachineExists = errors.New("state machine already exists")
+	// ErrInvalidState indicates that the specified state is not valid for the state machine.
+	ErrInvalidState = errors.New("invalid state")
+	// ErrInvalidTrigger indicates that the specified trigger is not valid for the current state.
+	ErrInvalidTrigger = errors.New("invalid trigger")
+	// ErrInvalidTransition indicates that the requested state transition is not allowed.
+	ErrInvalidTransition = errors.New("invalid state transition")
+	// ErrTransitionTimeout indicates that a state transition exceeded the configured timeout.
+	ErrTransitionTimeout = errors.New("state transition timeout")
+	// ErrTransitionGuardFailed indicates that a transition guard condition was not met.
+	ErrTransitionGuardFailed = errors.New("transition guard condition failed")
+	// ErrStateActionFailed indicates that a state entry or exit action failed.
+	ErrStateActionFailed = errors.New("state action failed")
+	// ErrTransitionActionFailed indicates that a transition action failed.
+	ErrTransitionActionFailed = errors.New("transition action failed")
+	// ErrStateMachineLocked indicates that the state machine is locked and cannot be modified.
+	ErrStateMachineLocked = errors.New("state machine is locked")
+	// ErrConcurrentModification indicates that a concurrent modification was attempted.
+	ErrConcurrentModification = errors.New("concurrent modification detected")
+	// ErrPersistenceFailed indicates that persisting the state failed.
+	ErrPersistenceFailed = errors.New("failed to persist state")
+	// ErrNilContext indicates that a nil context was provided.
+	ErrNilContext = errors.New("context cannot be nil")
+	// ErrNilCallback indicates that a nil callback was provided.
+	ErrNilCallback = errors.New("callback cannot be nil")
+	// ErrAlreadyInState indicates that the state machine is already in the requested state.
+	ErrAlreadyInState = errors.New("already in requested state")
+	// ErrStateMachineNotStarted indicates that the state machine has not been started.
+	ErrStateMachineNotStarted = errors.New("state machine not started")
+	// ErrStateMachineAlreadyStarted indicates that the state machine has already been started.
+	ErrStateMachineAlreadyStarted = errors.New("state machine already started")
+	// ErrStateMachineStopped indicates that the state machine has been stopped.
+	ErrStateMachineStopped = errors.New("state machine stopped")
+)

--- a/pkg/state/state.go
+++ b/pkg/state/state.go
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package state
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/qmuntal/stateless"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// FSM provides a thread-safe finite state machine implementation
+// with support for guards, actions, and persistence.
+type FSM struct {
+	config  *Config
+	machine *stateless.StateMachine
+	mu      sync.RWMutex
+	tracer  trace.Tracer
+	started bool
+	stopped bool
+
+	currentState      string
+	stateActions      map[string]StateDefinition
+	transitionMap     map[string]map[string]TransitionDefinition
+	persistCallback   PersistenceCallback
+	broadcastCallback BroadcastCallback
+}
+
+// PersistenceCallback is called when state needs to be persisted.
+type PersistenceCallback func(machineName, state string) error
+
+// BroadcastCallback is called when state changes need to be broadcast.
+type BroadcastCallback func(machineName, previousState, currentState string, trigger string) error
+
+// New creates a new state machine with the provided configuration.
+func New(config *Config) (*FSM, error) {
+	if config == nil {
+		return nil, ErrInvalidConfig
+	}
+
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	sm := &FSM{
+		config:        config,
+		currentState:  config.InitialState,
+		stateActions:  make(map[string]StateDefinition),
+		transitionMap: make(map[string]map[string]TransitionDefinition),
+	}
+
+	if config.EnableTracing {
+		sm.tracer = otel.Tracer("state")
+	}
+
+	sm.machine = stateless.NewStateMachine(config.InitialState)
+
+	for _, state := range config.States {
+		sm.stateActions[state.Name] = state
+		sm.configureState(state)
+	}
+
+	for _, transition := range config.Transitions {
+		sm.configureTransition(transition)
+	}
+
+	return sm, nil
+}
+
+// SetPersistenceCallback sets the callback for state persistence.
+func (sm *FSM) SetPersistenceCallback(callback PersistenceCallback) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.started {
+		return ErrStateMachineAlreadyStarted
+	}
+
+	sm.persistCallback = callback
+	return nil
+}
+
+// SetBroadcastCallback sets the callback for state change broadcasts.
+func (sm *FSM) SetBroadcastCallback(callback BroadcastCallback) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.started {
+		return ErrStateMachineAlreadyStarted
+	}
+
+	sm.broadcastCallback = callback
+	return nil
+}
+
+// Start initializes and starts the state machine.
+func (sm *FSM) Start(ctx context.Context) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if sm.started {
+		return nil
+	}
+
+	if sm.stopped {
+		return ErrStateMachineStopped
+	}
+
+	sm.started = true
+
+	if sm.config.PersistState && sm.persistCallback != nil {
+		if err := sm.persistCallback(sm.config.Name, sm.currentState); err != nil {
+			return fmt.Errorf("%w: %w", ErrPersistenceFailed, err)
+		}
+	}
+
+	return nil
+}
+
+// Stop gracefully stops the state machine.
+func (sm *FSM) Stop(ctx context.Context) error {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+
+	if !sm.started || sm.stopped {
+		return nil
+	}
+
+	sm.stopped = true
+	return nil
+}
+
+// Fire triggers a state transition with the specified trigger.
+func (sm *FSM) Fire(ctx context.Context, trigger string, data map[string]any) error {
+	sm.mu.Lock()
+
+	if !sm.started {
+		sm.mu.Unlock()
+		return ErrStateMachineNotStarted
+	}
+
+	if sm.stopped {
+		sm.mu.Unlock()
+		return ErrStateMachineStopped
+	}
+
+	var span trace.Span
+	if sm.tracer != nil {
+		ctx, span = sm.tracer.Start(ctx, "state.Fire",
+			trace.WithAttributes(
+				attribute.String("state_machine.name", sm.config.Name),
+				attribute.String("state.current", sm.currentState),
+				attribute.String("trigger", trigger),
+			))
+		defer span.End()
+	}
+
+	if ok, err := sm.machine.CanFire(trigger); err != nil {
+		sm.mu.Unlock()
+		return fmt.Errorf("%w: trigger %s not valid in state %s: %w", ErrInvalidTrigger, trigger, sm.currentState, err)
+	} else if !ok {
+		sm.mu.Unlock()
+		return fmt.Errorf("%w: trigger %s not valid in state %s", ErrInvalidTrigger, trigger, sm.currentState)
+	}
+
+	previousState := sm.currentState
+
+	timeout := sm.config.StateTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
+	fireCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		if err := sm.machine.FireCtx(fireCtx, trigger); err != nil {
+			done <- fmt.Errorf("%w: %w", ErrInvalidTransition, err)
+			return
+		}
+		done <- nil
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			if span != nil {
+				span.RecordError(err)
+			}
+			sm.mu.Unlock()
+			return err
+		}
+	case <-fireCtx.Done():
+		if fireCtx.Err() == context.DeadlineExceeded {
+			sm.mu.Unlock()
+			return ErrTransitionTimeout
+		}
+		sm.mu.Unlock()
+		return fireCtx.Err()
+	}
+
+	state, err := sm.machine.State(ctx)
+	if err != nil {
+		if span != nil {
+			span.RecordError(err)
+		}
+		sm.mu.Unlock()
+		return fmt.Errorf("failed to get current state: %w", err)
+	}
+	sm.currentState = fmt.Sprintf("%v", state)
+
+	// Capture values and callbacks, then unlock before invoking external code.
+	name := sm.config.Name
+	curr := sm.currentState
+	persistEnabled := sm.config.PersistState
+	persistCb := sm.persistCallback
+	broadcastCb := sm.broadcastCallback
+	sm.mu.Unlock()
+
+	if persistEnabled && persistCb != nil {
+		if perr := persistCb(name, curr); perr != nil {
+			if span != nil {
+				span.RecordError(perr)
+			}
+			return fmt.Errorf("%w: %w", ErrPersistenceFailed, perr)
+		}
+	}
+	if broadcastCb != nil {
+		if berr := broadcastCb(name, previousState, curr, trigger); berr != nil && span != nil {
+			span.RecordError(berr)
+		}
+	}
+
+	if span != nil {
+		span.SetAttributes(
+			attribute.String("state.previous", previousState),
+			attribute.String("state.new", curr),
+		)
+	}
+
+	return nil
+}
+
+// CurrentState returns the current state of the state machine.
+func (sm *FSM) CurrentState() string {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	return sm.currentState
+}
+
+// CanFire checks if the specified trigger can be fired from the current state.
+func (sm *FSM) CanFire(trigger string) (bool, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	return sm.machine.CanFire(trigger)
+}
+
+// PermittedTriggers returns all triggers that can be fired from the current state.
+func (sm *FSM) PermittedTriggers() []string {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	triggers, err := sm.machine.PermittedTriggers()
+	if err != nil {
+		return []string{}
+	}
+
+	result := make([]string, len(triggers))
+	for i, t := range triggers {
+		result[i] = fmt.Sprintf("%v", t)
+	}
+	return result
+}
+
+// IsInState checks if the state machine is in the specified state.
+func (sm *FSM) IsInState(state string) bool {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	return sm.currentState == state
+}
+
+// Name returns the name of the state machine.
+func (sm *FSM) Name() string {
+	return sm.config.Name
+}
+
+// Description returns the description of the state machine.
+func (sm *FSM) Description() string {
+	return sm.config.Description
+}
+
+// GetStateInfo returns information about a specific state.
+func (sm *FSM) GetStateInfo(state string) (StateDefinition, error) {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	def, exists := sm.stateActions[state]
+	if !exists {
+		return StateDefinition{}, fmt.Errorf("%w: %s", ErrInvalidState, state)
+	}
+
+	return def, nil
+}
+
+// ToGraph returns a DOT graph representation of the state machine.
+func (sm *FSM) ToGraph() string {
+	sm.mu.RLock()
+	defer sm.mu.RUnlock()
+
+	return sm.machine.ToGraph()
+}
+
+func (sm *FSM) configureState(state StateDefinition) {
+	stateConfig := sm.machine.Configure(state.Name)
+
+	if state.OnEntry != nil {
+		stateConfig.OnEntry(func(ctx context.Context, args ...any) error {
+			return state.OnEntry(ctx)
+		})
+	}
+
+	if state.OnExit != nil {
+		stateConfig.OnExit(func(ctx context.Context, args ...any) error {
+			return state.OnExit(ctx)
+		})
+	}
+}
+
+func (sm *FSM) configureTransition(transition TransitionDefinition) {
+	if sm.transitionMap[transition.From] == nil {
+		sm.transitionMap[transition.From] = make(map[string]TransitionDefinition)
+	}
+	sm.transitionMap[transition.From][transition.Trigger] = transition
+
+	fromCfg := sm.machine.Configure(transition.From)
+
+	if transition.Guard != nil {
+		fromCfg.PermitDynamic(transition.Trigger, func(ctx context.Context, args ...any) (any, error) {
+			if transition.Guard(ctx) {
+				return transition.To, nil
+			}
+			return nil, fmt.Errorf("guard condition failed")
+		})
+	} else {
+		fromCfg.Permit(transition.Trigger, transition.To)
+	}
+
+	if transition.Action != nil {
+		toCfg := sm.machine.Configure(transition.To)
+		toCfg.OnEntryFrom(transition.Trigger, func(ctx context.Context, args ...any) error {
+			return transition.Action(ctx, transition.From, transition.To)
+		})
+	}
+}
+
+// Manager manages multiple state machines.
+type Manager struct {
+	machines map[string]*FSM
+	mu       sync.RWMutex
+}
+
+// NewManager creates a new state machine manager.
+func NewManager() *Manager {
+	return &Manager{
+		machines: make(map[string]*FSM),
+	}
+}
+
+// AddStateMachine adds a state machine to the manager.
+func (m *Manager) AddStateMachine(sm *FSM) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if sm == nil {
+		return fmt.Errorf("%w: nil state machine", ErrInvalidConfig)
+	}
+
+	if _, exists := m.machines[sm.Name()]; exists {
+		return fmt.Errorf("%w: %s", ErrStateMachineExists, sm.Name())
+	}
+
+	m.machines[sm.Name()] = sm
+	return nil
+}
+
+// RemoveStateMachine removes a state machine from the manager.
+func (m *Manager) RemoveStateMachine(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, exists := m.machines[name]; !exists {
+		return fmt.Errorf("%w: %s", ErrStateMachineNotFound, name)
+	}
+
+	delete(m.machines, name)
+	return nil
+}
+
+// GetStateMachine retrieves a state machine by name.
+func (m *Manager) GetStateMachine(name string) (*FSM, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	sm, exists := m.machines[name]
+	if !exists {
+		return nil, fmt.Errorf("%w: %s", ErrStateMachineNotFound, name)
+	}
+
+	return sm, nil
+}
+
+// ListStateMachines returns the names of all managed state machines.
+func (m *Manager) ListStateMachines() []string {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	names := make([]string, 0, len(m.machines))
+	for name := range m.machines {
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// StopAll stops all managed state machines.
+func (m *Manager) StopAll(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var errs []error
+	for _, sm := range m.machines {
+		if err := sm.Stop(ctx); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable, thread-safe finite state machine: states, transitions, guards, entry/exit actions, persistence & broadcast callbacks, DOT export, lifecycle control, transition timeouts, observability (metrics/tracing) toggles, and a multi-machine manager.

- **Documentation**
  - Added comprehensive package docs with concepts, usage examples, callbacks, manager patterns, error types, and observability/persistence guidance.

- **Chores**
  - Dependency updates: added a state-machine library and promoted OpenTelemetry tracing to a direct dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->